### PR TITLE
 Add commit linting and contributing guidelines

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["@commitlint/config-conventional"]
+}

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": ["@commitlint/config-conventional"],
+    "rules": {
+      "header-max-length": [2, "always", 140]
+    }
 }

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require review from Caden
+* @cadenlund

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,16 @@
+name: Lint Commits
+on: [pull_request]
+
+jobs:
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            # Step 1: "Check-out" the code
+            - uses: actions/checkout@v3
+              with:
+                fetch-depth: 0 # 0 gets all commits in a pr
+
+            # Step 2: Check commits and enforce rules
+            - uses: wagoid/commitlint-github-action@v5
+              with:
+                configFile: .commitlintrc.json

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,7 @@
 name: Lint Commits
 on: [pull_request]
 
-# Permission so that github action can checkout
+# Permission so that github action can checkout(read repo)
 permissions:
     contents: read
     pull-requests: read

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,11 @@
 name: Lint Commits
 on: [pull_request]
 
+# Permission so that github action can checkout
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     commitlint:
         runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# How to contribute
+
+## Initial Steps
+
+ * Install python 3.9 or higher (python 3.12 reccomended) from python website or system package manager
+ * Check python version: `python3 --version'
+
+ * Call 225-975-5921 if you are unsure or have questions. 
+
+### 1. Clone repo
+```bash
+git clone https://github.com/algoflow-quant/algoflow.git
+cd algoflow
+```
+
+### 2. Install dependencies
+
+#### Frontend Setup:
+N/A Contact Caden Lund for more
+
+#### Backend Setup:
+```bash
+cd backend
+python3 -m venv venv
+source venv/bin/activate # On windows this is: venv\Scripts\activate   
+pip install -r requirements.txt
+```
+ * Windows users should use WSL for development
+
+### 3. Setup commit tools
+
+#### Install commitizen for easy guided commits:
+```bash
+# Install pipx for global python packages
+pip install --user pipx # Or pip3 install
+# Install commitizen for guided commits
+pipx install commitizen
+pipx ensurepath
+
+# Now use the following in place of git commit
+cz commit # Provides interactive helper for formatting
+```
+
+#### Install pre-commit hooks (Optional but reccommended, catch commit errors before pushing to online repo):
+
+**IMPORTANT**
+ * You will have to redo commit messages if they are in the wrong format!!!
+ * Note that github actions will prevent you from committing improper messages to the repo. 
+
+```bash
+# Install pre-commit
+pipx install pre-commit
+# Install the git hook
+pre-commit install --hook-type commit-msg
+# Now bad commits get blocked locally (faster feedback)
+```
+
+## Commit message formatting rules
+
+All commits must follow the Conventional Commits format:
+
+`type(scope): description`
+
+Can also have a body and footer
+
+### Types (Required)
+- **feat**: New feature for the user
+- **fix**: Bug fix for the user
+- **docs**: Documentation only changes
+- **style**: Code style changes (formatting, semicolons, etc)
+- **refactor**: Code change that neither fixes a bug nor adds a feature
+- **perf**: Performance improvements
+- **test**: Adding or updating tests
+- **build**: Changes to build system or dependencies
+- **ci**: Changes to CI configuration files and scripts
+- **chore**: Other changes that don't modify src or test files
+- **revert**: Reverts a previous commit
+
+### Scope (Optional)
+  The scope should indicate what part of the codebase changed:
+  - `backend`, `frontend`, `api`, `db`, `auth`, `ui`, etc.
+
+### Description Rules
+  - Use imperative mood ("add" not "added" or "adds")
+  - Don't capitalize first letter
+  - No period at the end
+  - Keep under 72 characters
+
+### Examples
+
+**Good commits:**
+```
+  feat(auth): add OAuth2 login with Google
+  fix(api): resolve timeout on stock api
+  docs: update stock database installation instructions in README
+```
+
+### Other stuff
+
+For breaking changes, add ! after type/scope and explain in body:
+
+`feat(api)!: change user endpoint response format`
+
+For complex changes, add a body:
+```bash
+  git commit -m "feat(backtest): integrate backtesting queue" -m "
+  - Addded priority queue for backtest nodes
+  - Created installation scripts to deploy multiple backtest nodes
+  - Added a load balancer to route backtests
+  - Update database schema"
+```
+
+## Branch workflow


### PR DESCRIPTION
## Summary changes
  - Added GitHub Actions workflow for commit message validation
  - Created contributing guide with setup instructions, tool installation, and commit guidelines
  - Configured commitlint for enforcing conventional commits
  - Added CODEOWNERS file to restrict modifying dev & main directly (needs my approval)