### PR TITLE
ci: add github workflow to run cz bump on merge to main and sync back…

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,63 @@
+name: Auto Version Bump
+
+# Trigger when PR from dev to main is merged
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    # Only run if PR was merged (not just closed) and source branch was dev
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout main branch with full history
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 2: Configure git
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Step 3: Install Python
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      # Step 4: Install commitizen
+      - name: Install commitizen
+        run: pip install commitizen
+
+      # Step 5: Run cz bump (auto-detects version from commits)
+      - name: Bump version with commitizen
+        run: |
+          cz bump --yes --changelog
+        env:
+          SKIP_PRE_COMMIT: 1
+
+      # Step 6: Push changes to main
+      - name: Push changes to main
+        run: |
+          git push origin main --follow-tags
+
+      # Step 7: Merge main back to dev to sync version
+      - name: Sync version back to dev
+        run: |
+          git fetch origin dev:dev
+          git checkout dev
+          git merge main --no-ff -m "chore: sync version bump from main [skip ci]"
+          git push origin dev


### PR DESCRIPTION
## Description
add github workflow to run cz bump on merge to main and sync back to dev

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- added workflow file

## Testing
N/A

## Screenshots (if applicable)
Add screenshots for UI changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
N/A